### PR TITLE
Define stop place polygon with list of coordinates

### DIFF
--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -208,6 +208,8 @@
   "stopPlaces.editor.loadingStopPlaceText": "Loading stop place",
   "stopPlaces.editor.nameFormLabelText": "* Name",
   "stopPlaces.editor.privateCodeFormLabelText": "Private code",
+  "stopPlaces.editor.coordinatesFormLabelText": "Coordinates",
+  "stopPlaces.editor.drawPolygonButtonText": "Draw polygon",
   "stopPlaces.editor.saveButtonText": "Save",
   "stopPlaces.editor.savingOverlayLoaderText": "Saving stop place...",
   "stopPlaces.editor.validateForm.errorFlexibleAreaNotEnoughPolygons": "You must add more map points",

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -208,7 +208,7 @@
   "stopPlaces.editor.loadingStopPlaceText": "Loading stop place",
   "stopPlaces.editor.nameFormLabelText": "* Name",
   "stopPlaces.editor.privateCodeFormLabelText": "Private code",
-  "stopPlaces.editor.coordinatesFormLabelText": "Coordinates",
+  "stopPlaces.editor.coordinatesFormLabelText": "Coordinates in GeoJson order [Long, Lat]",
   "stopPlaces.editor.drawPolygonButtonText": "Draw polygon",
   "stopPlaces.editor.saveButtonText": "Save",
   "stopPlaces.editor.savingOverlayLoaderText": "Saving stop place...",

--- a/src/i18n/translations/nb.json
+++ b/src/i18n/translations/nb.json
@@ -208,6 +208,8 @@
   "stopPlaces.editor.loadingStopPlaceText": "Laster inn stoppestedet",
   "stopPlaces.editor.nameFormLabelText": "* Navn",
   "stopPlaces.editor.privateCodeFormLabelText": "Privat kode",
+  "stopPlaces.editor.coordinatesFormLabelText": "Koordinater",
+  "stopPlaces.editor.drawPolygonButtonText": "Tegn polygon",
   "stopPlaces.editor.saveButtonText": "Lagre",
   "stopPlaces.editor.savingOverlayLoaderText": "Lagrer stoppestedet...",
   "stopPlaces.editor.validateForm.errorFlexibleAreaNotEnoughPolygons": "Du må legge til flere punkter i kartet",

--- a/src/i18n/translations/nb.json
+++ b/src/i18n/translations/nb.json
@@ -208,7 +208,7 @@
   "stopPlaces.editor.loadingStopPlaceText": "Laster inn stoppestedet",
   "stopPlaces.editor.nameFormLabelText": "* Navn",
   "stopPlaces.editor.privateCodeFormLabelText": "Privat kode",
-  "stopPlaces.editor.coordinatesFormLabelText": "Koordinater",
+  "stopPlaces.editor.coordinatesFormLabelText": "Koordinater i GeoJson-rekkefølge [Long, Lat]",
   "stopPlaces.editor.drawPolygonButtonText": "Tegn polygon",
   "stopPlaces.editor.saveButtonText": "Lagre",
   "stopPlaces.editor.savingOverlayLoaderText": "Lagrer stoppestedet...",

--- a/src/scenes/StopPlaces/scenes/Editor/components/PolygonMap/index.js
+++ b/src/scenes/StopPlaces/scenes/Editor/components/PolygonMap/index.js
@@ -10,22 +10,23 @@ class PolygonMap extends Component {
       lng: 10.76
     },
     bounds: undefined,
-    zoom: 12
+    zoom: 14
   };
 
   map = createRef();
 
   setPolygonRef(element) {
-    if (element && !this.polygonRefLoaded) {
+    if (element) {
       const bounds = element.leafletElement.getBounds();
-      if (bounds.isValid()) {
+      if (this.isBoundsValid(bounds) && bounds !== this.state.bounds) {
         this.setState({ bounds });
       }
     }
+  }
 
-    if (element != null) {
-      this.polygonRefLoaded = true;
-    }
+  isBoundsValid(bounds) {
+    if (!bounds || !bounds.isValid()) return false;
+    return !bounds.getSouthWest().equals(bounds.getNorthEast());
   }
 
   componentDidMount() {

--- a/src/scenes/StopPlaces/scenes/Editor/messages.js
+++ b/src/scenes/StopPlaces/scenes/Editor/messages.js
@@ -43,7 +43,7 @@ export default defineMessages({
   },
   coordinatesFormLabelText: {
     id: 'stopPlaces.editor.coordinatesFormLabelText',
-    defaultMessage: 'Koordinater'
+    defaultMessage: 'Koordinater i GeoJson-rekkefølge [Long, Lat]'
   },
   loadingStopPlaceText: {
     id: 'stopPlaces.editor.loadingStopPlaceText',

--- a/src/scenes/StopPlaces/scenes/Editor/messages.js
+++ b/src/scenes/StopPlaces/scenes/Editor/messages.js
@@ -17,6 +17,10 @@ export default defineMessages({
     id: 'stopPlaces.editor.deleteButtonText',
     defaultMessage: 'Slett'
   },
+  drawPolygonButtonText: {
+    id: 'stopPlaces.editor.drawPolygonButtonText',
+    defaultMessage: 'Tegn polygon'
+  },
   savingOverlayLoaderText: {
     id: 'stopPlaces.editor.savingOverlayLoaderText',
     defaultMessage: 'Lagrer stoppestedet...'
@@ -36,6 +40,10 @@ export default defineMessages({
   privateCodeFormLabelText: {
     id: 'stopPlaces.editor.privateCodeFormLabelText',
     defaultMessage: 'Privat kode'
+  },
+  coordinatesFormLabelText: {
+    id: 'stopPlaces.editor.coordinatesFormLabelText',
+    defaultMessage: 'Koordinater'
   },
   loadingStopPlaceText: {
     id: 'stopPlaces.editor.loadingStopPlaceText',

--- a/src/scenes/StopPlaces/scenes/Editor/styles.scss
+++ b/src/scenes/StopPlaces/scenes/Editor/styles.scss
@@ -50,4 +50,9 @@
     flex-direction: column;
     justify-content: center;
   }
+
+  textarea::placeholder {
+    color: #bbb;
+    font-size: 12px;
+  }
 }


### PR DESCRIPTION
The MVP version of a feature that lets us define stop place polygons with a list of coordinates instead of drawing it ourselves. 
It currently has very rudimentary error handling, and is mostly suited to expert users (ourselves).
If this feature works and is valuable in practice, maybe the next version of it should be upload of geojson-files (with validation).