### PR TITLE
En gyldig operatør må ha netexOperatorId

### DIFF
--- a/src/scenes/Lines/scenes/Editor/index.js
+++ b/src/scenes/Lines/scenes/Editor/index.js
@@ -164,8 +164,10 @@ const FlexibleLineEditor = ({ match, history }) => {
     );
   };
 
-  const operators = organisations.filter(org =>
-    org.types.includes(ORGANISATION_TYPE.OPERATOR)
+  const operators = organisations.filter(
+    org =>
+      org.types.includes(ORGANISATION_TYPE.OPERATOR) &&
+      org.references.netexOperatorId
   );
 
   const isLoadingLine = !flexibleLine;


### PR DESCRIPTION
Nå skal vi kun vise operatører som har en netexOperatorId i operatør-valget. Dette burde gi mange færre ORGANISATION_NOT_VALID_OPERATOR-meldinger når vi lager linjer.