### PR TITLE
Improved error-message handling for network failure

### DIFF
--- a/src/actions/networks.js
+++ b/src/actions/networks.js
@@ -6,7 +6,7 @@ import {
   showErrorNotification,
   showSuccessNotification
 } from 'components/Notification/actions';
-import { getUttuError } from 'helpers/uttu';
+import { getStyledUttuError } from 'helpers/uttu';
 
 export const REQUEST_NETWORKS = 'REQUEST_NETWORKS';
 export const RECEIVE_NETWORKS = 'RECEIVE_NETWORKS';
@@ -69,7 +69,12 @@ export const loadNetworks = () => async (dispatch, getState) => {
   } catch (e) {
     dispatch(
       showErrorNotification(
-        `En feil oppstod under lastingen av nettverkene: ${getUttuError(e)}`
+        'Laste nettverk',
+        getStyledUttuError(
+          e,
+          'En feil oppstod under lastingen av nettverkene',
+          'Prøv igjen senere.'
+        )
       )
     );
     throw e;
@@ -90,7 +95,11 @@ export const loadNetworkById = id => async (dispatch, getState) => {
     dispatch(
       showErrorNotification(
         'Laste nettverk',
-        `En feil oppstod under lastingen av nettverket: ${getUttuError(e)}`
+        getStyledUttuError(
+          e,
+          'En feil oppstod under lastingen av nettverket',
+          'Prøv igjen senere.'
+        )
       )
     );
     throw e;
@@ -113,7 +122,11 @@ export const saveNetwork = network => async (dispatch, getState) => {
     dispatch(
       showErrorNotification(
         'Lagre nettverk',
-        `En feil oppstod under lagringen av nettverket: ${getUttuError(e)}`
+        getStyledUttuError(
+          e,
+          'En feil oppstod under lagringen av nettverket',
+          'Prøv igjen senere.'
+        )
       )
     );
     throw e;
@@ -134,7 +147,7 @@ export const deleteNetworkById = id => async (dispatch, getState) => {
     dispatch(
       showErrorNotification(
         'Slette nettverk',
-        `En feil oppstod under slettingen av nettverket: ${getUttuError(e)}`
+        getStyledUttuError(e, 'En feil oppstod under slettingen av nettverket')
       )
     );
     throw e;

--- a/src/components/Notification/styles.scss
+++ b/src/components/Notification/styles.scss
@@ -55,6 +55,10 @@
   .notification-bar-label {
     margin-left: 10px;
   }
+
+  .notification-icon {
+    display: flex;
+  }
 }
 
 .notification-bar-message {

--- a/src/helpers/uttu.js
+++ b/src/helpers/uttu.js
@@ -1,12 +1,11 @@
 import messages from './uttu.messages';
 
-export const getUttuError = e => {
-  return e.response?.errors &&
-    e.response.errors?.length &&
-    e.response.errors[0].message
-    ? e.response.errors[0].message
-    : null;
-};
+export const getUttuError = e => e.response?.errors?.[0]?.message ?? null;
+
+export const getStyledUttuError = (e, generalMessage, fallback = '') =>
+  getUttuError(e)
+    ? `${generalMessage}: ${getUttuError(e)}`
+    : `${generalMessage}. ${fallback}`;
 
 const validErrorCodes = [
   'UNKNOWN',


### PR DESCRIPTION
Avoid printing `null` to user, by checking the feedback's content first. Also added a missing title to one of the feedback messages.