### PR TITLE
Fixed date picker bug

### DIFF
--- a/src/scenes/Lines/scenes/Editor/ServiceJourneys/Editor/index.tsx
+++ b/src/scenes/Lines/scenes/Editor/ServiceJourneys/Editor/index.tsx
@@ -161,7 +161,12 @@ const ServiceJourneyEditor = (props: Props) => {
                 onChange({
                   ...serviceJourney,
                   dayTypes: [
-                    { ...serviceJourney.dayTypes?.[0]!, daysOfWeek: dow },
+                    {
+                      ...(serviceJourney.dayTypes?.[0] ?? {
+                        dayTypeAssignments: [newDayTypeAssignment()],
+                      }),
+                      daysOfWeek: dow,
+                    },
                   ],
                 })
               }


### PR DESCRIPTION
The DayTypeAssignment had a bug, that did not allow the user to use the initial filled date (date.now()) without trigger a change. Quick-fix to solve the problem, but the DayType data structure should probably be handled in a better way in the future