### PR TITLE
Flexible areas only design

### DIFF
--- a/src/helpers/errorHandling.ts
+++ b/src/helpers/errorHandling.ts
@@ -6,5 +6,5 @@ export const getErrorFeedback = (
   isValid: boolean,
   isPristine: boolean
 ): ErrorHandling => {
-  return isPristine || isValid ? {} : { feedback: feedback, variant: 'error' };
+  return isPristine || isValid ? {} : { feedback, variant: 'error' };
 };

--- a/src/i18n/translations/en.ts
+++ b/src/i18n/translations/en.ts
@@ -279,6 +279,7 @@ export const messages: MessagesKey = {
   flexibleStopPlaceRefAndQuayRefBothValues:
     'Choose either stop place or platform, not both.',
   flexibleStopPlaceRefAndQuayRefNoValues: 'You must a place',
+  flexibleStopPlaceNoValue: 'You must select a stop place',
   frontTextNoValue: 'You must enter a front text',
   frontTextAlighting: 'First stop can only be for boarding',
   frontTextBoarding: 'Last stop can only be for alighting',

--- a/src/i18n/translations/nb.ts
+++ b/src/i18n/translations/nb.ts
@@ -288,6 +288,7 @@ export const messages = {
   flexibleStopPlaceRefAndQuayRefBothValues:
     'Velg enten stoppested eller plattform, ikke begge.',
   flexibleStopPlaceRefAndQuayRefNoValues: 'Du må velge et sted',
+  flexibleStopPlaceNoValue: 'Du må velge et stoppested',
   frontTextNoValue: 'Du må oppgi fronttekst',
   frontTextAlighting: 'Første stopp kan kun ha påstigning',
   frontTextBoarding: 'Siste stopp kan kun ha avstigning',

--- a/src/scenes/Lines/scenes/Editor/General/index.tsx
+++ b/src/scenes/Lines/scenes/Editor/General/index.tsx
@@ -50,7 +50,6 @@ export default ({
   const networkPristine = usePristine(flexibleLine.network?.id, spoilPristine);
   const operatorPristine = usePristine(flexibleLine.operatorRef, spoilPristine);
   const lineTypePristine = usePristine(flexibleLineType, spoilPristine);
-  console.log({ flexibleLine });
 
   const onFlexibleLineTypeChange = (flexibleLineType: string | undefined) => {
     if (flexibleLineType !== 'flexibleAreasOnly') {

--- a/src/scenes/Lines/scenes/Editor/General/index.tsx
+++ b/src/scenes/Lines/scenes/Editor/General/index.tsx
@@ -12,6 +12,8 @@ import { Organisation } from 'reducers/organisations';
 import FlexibleLineTypeDrawer from './FlexibleLineTypeDrawer';
 import { usePristine } from 'scenes/Lines/scenes/Editor/hooks';
 import { getErrorFeedback } from 'helpers/errorHandling';
+import ServiceJourney from 'model/ServiceJourney';
+import JourneyPattern from 'model/JourneyPattern';
 
 type Props = {
   flexibleLine: FlexibleLine;
@@ -48,6 +50,35 @@ export default ({
   const networkPristine = usePristine(flexibleLine.network?.id, spoilPristine);
   const operatorPristine = usePristine(flexibleLine.operatorRef, spoilPristine);
   const lineTypePristine = usePristine(flexibleLineType, spoilPristine);
+  console.log({ flexibleLine });
+
+  const onFlexibleLineTypeChange = (flexibleLineType: string | undefined) => {
+    if (flexibleLineType !== 'flexibleAreasOnly') {
+      return flexibleLineChange({ ...flexibleLine, flexibleLineType });
+    }
+
+    const journeyPatterns = flexibleLine.journeyPatterns ?? [];
+    const { serviceJourneys } = journeyPatterns[0];
+
+    flexibleLineChange({
+      ...flexibleLine,
+      journeyPatterns: journeyPatterns.map((journeyPattern: JourneyPattern) => {
+        return {
+          ...journeyPattern,
+          serviceJourneys: serviceJourneys.map(
+            (serviceJourney: ServiceJourney) => {
+              return {
+                ...serviceJourney,
+                passingTimes: [{}, {}],
+              };
+            }
+          ),
+          pointsInSequence: [{}, {}],
+        };
+      }),
+      flexibleLineType,
+    });
+  };
 
   return (
     <div className="lines-editor-general">
@@ -176,12 +207,7 @@ export default ({
               })),
             ]}
             label={formatMessage('generalTypeFormGroupTitle')}
-            onChange={(element) =>
-              flexibleLineChange({
-                ...flexibleLine,
-                flexibleLineType: element?.value,
-              })
-            }
+            onChange={(element) => onFlexibleLineTypeChange(element?.value)}
             {...getErrorFeedback(
               formatMessage('networkRefEmpty'),
               !flexibleLineTypeError,

--- a/src/scenes/Lines/scenes/Editor/JourneyPatterns/Editor/StopPoints/Editor/FlexibleAreasOnlyEditor.tsx
+++ b/src/scenes/Lines/scenes/Editor/JourneyPatterns/Editor/StopPoints/Editor/FlexibleAreasOnlyEditor.tsx
@@ -66,7 +66,7 @@ const FlexibleAreasOnlyEditor = (props: Props) => {
             })
           }
           {...getErrorFeedback(
-            'no stopPlace',
+            formatMessage('flexibleStopPlaceNoValue'),
             Boolean(stopPointValue),
             stopPlacePristine
           )}
@@ -76,7 +76,7 @@ const FlexibleAreasOnlyEditor = (props: Props) => {
       <InputGroup
         label={formatMessage('labelFrontText')}
         {...getErrorFeedback(
-          'no frontText',
+          formatMessage('frontTextNoValue'),
           !isBlank(frontText),
           frontTextPristine
         )}

--- a/src/scenes/Lines/scenes/Editor/JourneyPatterns/Editor/StopPoints/Editor/FlexibleAreasOnlyEditor.tsx
+++ b/src/scenes/Lines/scenes/Editor/JourneyPatterns/Editor/StopPoints/Editor/FlexibleAreasOnlyEditor.tsx
@@ -1,0 +1,99 @@
+import React, { ChangeEvent } from 'react';
+import { useSelector } from 'react-redux';
+import { InputGroup, TextField } from '@entur/form';
+import FlexibleStopPlace from 'model/FlexibleStopPlace';
+import StopPoint from 'model/StopPoint';
+import { Dropdown } from '@entur/dropdown';
+import { usePristine } from 'scenes/Lines/scenes/Editor/hooks';
+import { getErrorFeedback } from 'helpers/errorHandling';
+import { AppIntlState, selectIntl } from 'i18n';
+import { isBlank } from 'helpers/forms';
+import { GlobalState } from 'reducers';
+import './styles.scss';
+
+type Props = {
+  flexibleStopPlaces: FlexibleStopPlace[];
+  updateStopPoints: (stopPoints: StopPoint[]) => void;
+  stopPoints: StopPoint[];
+  spoilPristine: boolean;
+};
+const FlexibleAreasOnlyEditor = (props: Props) => {
+  const {
+    stopPoints,
+    flexibleStopPlaces,
+    updateStopPoints,
+    spoilPristine,
+  } = props;
+  const { formatMessage } = useSelector<GlobalState, AppIntlState>(selectIntl);
+  const [stopPoint, alightingStopPoint] = stopPoints;
+  const stopPointValue =
+    stopPoint.flexibleStopPlaceRef ?? stopPoint.flexibleStopPlace?.id;
+
+  const frontText = stopPoints[0].destinationDisplay?.frontText;
+  const stopPlacePristine = usePristine(stopPointValue, spoilPristine);
+  const frontTextPristine = usePristine(frontText, spoilPristine);
+
+  const stopPointChange = (stopPoint: StopPoint) => {
+    updateStopPoints([
+      {
+        ...stopPoint,
+        forBoarding: true,
+        forAlighting: false,
+      },
+      {
+        ...stopPoint,
+        id: alightingStopPoint?.id,
+        forBoarding: false,
+        forAlighting: true,
+      },
+    ]);
+  };
+
+  return (
+    <div className="flexible-areas-stop-points">
+      {
+        <Dropdown
+          label={formatMessage('stopPlace')}
+          value={stopPointValue}
+          items={flexibleStopPlaces.map((fsp) => ({
+            value: fsp.id,
+            label: fsp.name ?? '',
+          }))}
+          onChange={(e) =>
+            stopPointChange({
+              ...stopPoint,
+              flexibleStopPlaceRef: e?.value,
+            })
+          }
+          {...getErrorFeedback(
+            'no stopPlace',
+            Boolean(stopPointValue),
+            stopPlacePristine
+          )}
+        />
+      }
+
+      <InputGroup
+        label={formatMessage('labelFrontText')}
+        {...getErrorFeedback(
+          'no frontText',
+          !isBlank(frontText),
+          frontTextPristine
+        )}
+        labelTooltip={formatMessage('frontTextTooltip')}
+      >
+        <TextField
+          defaultValue={frontText}
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+            stopPointChange({
+              ...stopPoint,
+              destinationDisplay: { frontText: e.target.value },
+            })
+          }
+        />
+      </InputGroup>
+    </div>
+  );
+};
+
+export default FlexibleAreasOnlyEditor;

--- a/src/scenes/Lines/scenes/Editor/JourneyPatterns/Editor/StopPoints/Editor/index.tsx
+++ b/src/scenes/Lines/scenes/Editor/JourneyPatterns/Editor/StopPoints/Editor/index.tsx
@@ -35,6 +35,7 @@ type Props = {
   isFirstStop: boolean;
   deleteStopPoint?: () => void;
   spoilPristine: boolean;
+  flexibleLineType: string | undefined;
 };
 
 const StopPointEditor = ({

--- a/src/scenes/Lines/scenes/Editor/JourneyPatterns/Editor/StopPoints/Editor/styles.scss
+++ b/src/scenes/Lines/scenes/Editor/JourneyPatterns/Editor/StopPoints/Editor/styles.scss
@@ -55,3 +55,11 @@
     }
   }
 }
+
+.flexible-areas-stop-points {
+  max-width: 40%;
+
+  > div {
+    margin-bottom: 16px;
+  }
+}

--- a/src/scenes/Lines/scenes/Editor/JourneyPatterns/Editor/index.tsx
+++ b/src/scenes/Lines/scenes/Editor/JourneyPatterns/Editor/index.tsx
@@ -121,7 +121,6 @@ const JourneyPatternEditor = ({
   };
 
   const keys = useUniqueKeys(pointsInSequence);
-  console.log({ pointsInSequence });
 
   return (
     <div className="journey-pattern-editor">

--- a/src/scenes/Lines/scenes/Editor/JourneyPatterns/Editor/styles.scss
+++ b/src/scenes/Lines/scenes/Editor/JourneyPatterns/Editor/styles.scss
@@ -2,11 +2,11 @@
 
 .journey-pattern-inputs {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
+  max-width: 40%;
 
   .eds-input-group {
     flex: 40% 0;
-    margin-right: 2rem;
   }
 
   .eds-input-group + .eds-input-group {

--- a/src/scenes/Lines/scenes/Editor/JourneyPatterns/index.tsx
+++ b/src/scenes/Lines/scenes/Editor/JourneyPatterns/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { ExpandablePanel } from '@entur/expand';
 import { replaceElement, useUniqueKeys } from 'helpers/arrays';
 import JourneyPatternEditor from './Editor';
@@ -9,6 +9,7 @@ type Props = {
   journeyPatterns: JourneyPattern[];
   onChange: (journeyPatterns: JourneyPattern[]) => void;
   setIsValidJourneyPattern: (isValid: boolean) => void;
+  flexibleLineType: string | undefined;
   spoilPristine: boolean;
 };
 
@@ -17,21 +18,11 @@ const JourneyPatternsEditor = ({
   onChange,
   setIsValidJourneyPattern,
   spoilPristine,
+  flexibleLineType,
 }: Props) => {
-  useEffect(() => {
-    if (!journeyPatterns.length)
-      onChange([
-        {
-          pointsInSequence: [{}, {}],
-          serviceJourneys: [{ passingTimes: [{}, {}] }],
-        },
-      ]);
-  }, [journeyPatterns, onChange]);
-
   const handleSave = (journeyPattern: JourneyPattern, index: number) => {
     onChange(replaceElement(journeyPatterns, index, journeyPattern));
   };
-
   const keys = useUniqueKeys(journeyPatterns);
 
   return (
@@ -43,6 +34,7 @@ const JourneyPatternsEditor = ({
           index={0}
           setIsValidJourneyPattern={setIsValidJourneyPattern}
           spoilPristine={spoilPristine}
+          flexibleLineType={flexibleLineType}
         />
       ) : (
         journeyPatterns.map((jp: JourneyPattern, index: number) => (
@@ -57,6 +49,7 @@ const JourneyPatternsEditor = ({
               index={index}
               setIsValidJourneyPattern={setIsValidJourneyPattern}
               spoilPristine={spoilPristine}
+              flexibleLineType={flexibleLineType}
             />
           </ExpandablePanel>
         ))

--- a/src/scenes/Lines/scenes/Editor/ServiceJourneys/Editor/PassingTimesEditor/FlexibleAreasPassingTime.tsx
+++ b/src/scenes/Lines/scenes/Editor/ServiceJourneys/Editor/PassingTimesEditor/FlexibleAreasPassingTime.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import StopPoint from 'model/StopPoint';
+import FlexibleStopPlace from 'model/FlexibleStopPlace';
+import './styles.scss';
+
+type Props = {
+  flexibleStopPlaces: FlexibleStopPlace[];
+  stopPoints: StopPoint[];
+  children: any;
+};
+
+const FlexibleAreasPassingTime = (props: Props) => {
+  return <div className="flexible-areas-passing-time">{props.children}</div>;
+};
+
+export default FlexibleAreasPassingTime;

--- a/src/scenes/Lines/scenes/Editor/ServiceJourneys/Editor/PassingTimesEditor/index.tsx
+++ b/src/scenes/Lines/scenes/Editor/ServiceJourneys/Editor/PassingTimesEditor/index.tsx
@@ -119,8 +119,16 @@ const PassingTimesEditor = (props: Props & StateProps) => {
             flexibleStopPlaces={flexibleStopPlaces}
             stopPoints={stopPoints}
           >
-            {getTimePicker(passingTimes[0], 0, 'fra')}
-            {getTimePicker(passingTimes[1], 1, 'til')}
+            {getTimePicker(
+              passingTimes[0],
+              0,
+              formatMessage('dayTypeEditorFromDate')
+            )}
+            {getTimePicker(
+              passingTimes[1],
+              1,
+              formatMessage('dayTypeEditorToDate')
+            )}
           </FlexibleAreasPassingTime>
         ) : (
           passingTimes.map((passingTime, index) => (

--- a/src/scenes/Lines/scenes/Editor/ServiceJourneys/Editor/PassingTimesEditor/index.tsx
+++ b/src/scenes/Lines/scenes/Editor/ServiceJourneys/Editor/PassingTimesEditor/index.tsx
@@ -14,6 +14,7 @@ import { selectIntl } from 'i18n';
 import PassingTimeTitle from './PassingTimeTitle';
 import './styles.scss';
 import { getErrorFeedback } from 'helpers/errorHandling';
+import FlexibleAreasPassingTime from './FlexibleAreasPassingTime';
 
 type StateProps = {
   flexibleStopPlaces: FlexibleStopPlace[];
@@ -25,6 +26,7 @@ type Props = {
   stopPoints: StopPoint[];
   onChange: (pts: PassingTime[]) => void;
   spoilPristine: boolean;
+  flexibleLineType: string | undefined;
 };
 
 const PassingTimesEditor = (props: Props & StateProps) => {
@@ -35,6 +37,7 @@ const PassingTimesEditor = (props: Props & StateProps) => {
     onChange,
     flexibleStopPlaces,
     spoilPristine,
+    flexibleLineType,
   } = props;
   const { isValid, errorMessage } = validateTimes(passingTimes, intl);
   const { formatMessage } = useSelector(selectIntl);
@@ -69,17 +72,18 @@ const PassingTimesEditor = (props: Props & StateProps) => {
     return time + ':00';
   };
 
-  const getTimePicker = (passingTime: PassingTime, index: number) => {
+  const getTimePicker = (
+    passingTime: PassingTime,
+    index: number,
+    label: string
+  ) => {
     const shownValue = passingTime.departureTime
       ?.split(':')
       .slice(0, 2)
       .join(':');
 
     return (
-      <InputGroup
-        label={formatMessage('passingTimesPassingTime')}
-        className="timepicker"
-      >
+      <InputGroup label={label} className="timepicker">
         <TextField
           onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
             onChange(
@@ -110,17 +114,31 @@ const PassingTimesEditor = (props: Props & StateProps) => {
         <SmallAlertBox variant="error">{error.feedback}</SmallAlertBox>
       )}
       <div className="passing-times-editor">
-        {passingTimes.map((passingTime, index) => (
-          <div key={index} className="passing-time">
-            <div className="time-number">{index + 1}</div>
-            <PassingTimeTitle
-              flexibleStopPlaces={flexibleStopPlaces}
-              stopPoint={stopPoints[index]}
-            />
-            {getTimePicker(passingTime, index)}
-            {getDayOffsetDropdown(passingTime, index)}
-          </div>
-        ))}
+        {flexibleLineType === 'flexibleAreasOnly' ? (
+          <FlexibleAreasPassingTime
+            flexibleStopPlaces={flexibleStopPlaces}
+            stopPoints={stopPoints}
+          >
+            {getTimePicker(passingTimes[0], 0, 'fra')}
+            {getTimePicker(passingTimes[1], 1, 'til')}
+          </FlexibleAreasPassingTime>
+        ) : (
+          passingTimes.map((passingTime, index) => (
+            <div key={index} className="passing-time">
+              <div className="time-number">{index + 1}</div>
+              <PassingTimeTitle
+                flexibleStopPlaces={flexibleStopPlaces}
+                stopPoint={stopPoints[index]}
+              />
+              {getTimePicker(
+                passingTime,
+                index,
+                formatMessage('passingTimesPassingTime')
+              )}
+              {getDayOffsetDropdown(passingTime, index)}
+            </div>
+          ))
+        )}
       </div>
     </>
   );

--- a/src/scenes/Lines/scenes/Editor/ServiceJourneys/Editor/PassingTimesEditor/styles.scss
+++ b/src/scenes/Lines/scenes/Editor/ServiceJourneys/Editor/PassingTimesEditor/styles.scss
@@ -37,4 +37,8 @@
       width: fit-content;
     }
   }
+
+  .flexible-areas-passing-time {
+    display: flex;
+  }
 }

--- a/src/scenes/Lines/scenes/Editor/ServiceJourneys/Editor/PassingTimesEditor/styles.scss
+++ b/src/scenes/Lines/scenes/Editor/ServiceJourneys/Editor/PassingTimesEditor/styles.scss
@@ -40,5 +40,13 @@
 
   .flexible-areas-passing-time {
     display: flex;
+
+    .eds-form-control-wrapper {
+      width: 9.5rem;
+    }
+
+    > div:not(:last-child) {
+      margin-right: 16px;
+    }
   }
 }

--- a/src/scenes/Lines/scenes/Editor/ServiceJourneys/Editor/index.tsx
+++ b/src/scenes/Lines/scenes/Editor/ServiceJourneys/Editor/index.tsx
@@ -32,6 +32,7 @@ type Props = {
   spoilPristine: boolean;
   onChange: (serviceJourney: ServiceJourney) => void;
   deleteServiceJourney?: (index: number) => void;
+  flexibleLineType: string | undefined;
 };
 
 const ServiceJourneyEditor = (props: Props) => {
@@ -49,6 +50,7 @@ const ServiceJourneyEditor = (props: Props) => {
     stopPoints,
     serviceJourney,
     deleteServiceJourney,
+    flexibleLineType,
   } = props;
 
   const [operatorSelection, setOperatorSelection] = useState(
@@ -214,6 +216,7 @@ const ServiceJourneyEditor = (props: Props) => {
               stopPoints={stopPoints}
               onChange={(pts) => onFieldChange('passingTimes', pts)}
               spoilPristine={spoilPristine}
+              flexibleLineType={flexibleLineType}
             />
           </section>
         </div>

--- a/src/scenes/Lines/scenes/Editor/ServiceJourneys/index.tsx
+++ b/src/scenes/Lines/scenes/Editor/ServiceJourneys/index.tsx
@@ -21,6 +21,7 @@ type Props = {
   stopPoints: StopPoint[];
   setIsValidServiceJourney: (isValid: boolean) => void;
   spoilPristine: boolean;
+  flexibleLineType: string | undefined;
 };
 
 const ServiceJourneysEditor = ({
@@ -29,6 +30,7 @@ const ServiceJourneysEditor = ({
   stopPoints,
   setIsValidServiceJourney,
   spoilPristine,
+  flexibleLineType,
 }: Props) => {
   const [showModal, setShowModal] = useState<boolean>(false);
   const [keys, setKeys] = useState<number[]>(serviceJourneys.map(Math.random));
@@ -73,6 +75,7 @@ const ServiceJourneysEditor = ({
             ? () => deleteServiceJourney(index)
             : undefined
         }
+        flexibleLineType={flexibleLineType}
       />
     );
   };
@@ -136,7 +139,6 @@ const ServiceJourneysEditor = ({
                   {renderServiceJourneyEditor(sj, index)}
                 </ExpandablePanel>
               ))}
-
           <AddButton
             onClick={() => setShowModal(true)}
             buttonTitle={formatMessage('editorAddServiceJourneys')}

--- a/src/scenes/Lines/scenes/Editor/index.tsx
+++ b/src/scenes/Lines/scenes/Editor/index.tsx
@@ -72,7 +72,31 @@ const FlexibleLineEditor = ({
     setErrors(validateForm(flexibleLine));
   }, [flexibleLine]);
 
+<<<<<<< HEAD
   const goToLines = () => history.push('/lines');
+=======
+  useEffect(() => {
+    if (!flexibleLine.journeyPatterns) {
+      const journeyPattern = {
+        pointsInSequence: [{}, {}],
+        serviceJourneys: [{ passingTimes: [{}, {}] }],
+      };
+
+      onFieldChange({
+        ...flexibleLine,
+        journeyPatterns: [journeyPattern],
+      });
+    }
+  }, [flexibleLine, onFieldChange]);
+
+  const goToLines = () => {
+    if (!isSaved) {
+      setShowConfirm(true);
+    } else {
+      history.push('/lines');
+    }
+  };
+>>>>>>> FlexibleAreasOnly now only has one input field
 
   const dispatch = useDispatch<any>();
 
@@ -197,6 +221,7 @@ const FlexibleLineEditor = ({
                   onChange={(jps) =>
                     onFieldChange({ ...flexibleLine, journeyPatterns: jps })
                   }
+                  flexibleLineType={flexibleLine.flexibleLineType}
                   setIsValidJourneyPattern={setIsValidJourneyPattern}
                   spoilPristine={nextClicked}
                 />
@@ -225,6 +250,7 @@ const FlexibleLineEditor = ({
                       ),
                     })
                   }
+                  flexibleLineType={flexibleLine.flexibleLineType}
                 />
               </section>
             )}

--- a/src/scenes/Lines/scenes/Editor/index.tsx
+++ b/src/scenes/Lines/scenes/Editor/index.tsx
@@ -72,31 +72,7 @@ const FlexibleLineEditor = ({
     setErrors(validateForm(flexibleLine));
   }, [flexibleLine]);
 
-<<<<<<< HEAD
   const goToLines = () => history.push('/lines');
-=======
-  useEffect(() => {
-    if (!flexibleLine.journeyPatterns) {
-      const journeyPattern = {
-        pointsInSequence: [{}, {}],
-        serviceJourneys: [{ passingTimes: [{}, {}] }],
-      };
-
-      onFieldChange({
-        ...flexibleLine,
-        journeyPatterns: [journeyPattern],
-      });
-    }
-  }, [flexibleLine, onFieldChange]);
-
-  const goToLines = () => {
-    if (!isSaved) {
-      setShowConfirm(true);
-    } else {
-      history.push('/lines');
-    }
-  };
->>>>>>> FlexibleAreasOnly now only has one input field
 
   const dispatch = useDispatch<any>();
 


### PR DESCRIPTION
Different UI & UX for line type 'flexibleAreasOnly'!🌟

Some things worth knowing:
 - Only one input field in the `journeyPattern` & `serviceJourney`-step. The data model is still the same which means that it is still two stop points & passingTimes, even though only one is shown.
 - Now whenever one chooses `flexibleAreasOnly` as line type, the data is reset:ed to prevent issues between what is shown and what is actually stored data-wise.
