### PR TITLE
Use client name header on requests for stop places

### DIFF
--- a/src/graphql/index.js
+++ b/src/graphql/index.js
@@ -3,12 +3,19 @@ import { GraphQLClient } from 'graphql-request';
 import { API_BASE } from 'http/http';
 import token from 'http/token';
 
-const staticHeaders = { 'et-client-name': 'OT' };
+const staticHeaders = { 'ET-Client-Name': 'Entur - Flex editor' };
 
 export const UttuQuery = (provider, query, variables) => {
   const endpoint = API_BASE + '/uttu/' + provider;
   const client = new GraphQLClient(endpoint, {
     headers: { ...staticHeaders, authorization: token.getBearer() },
+  });
+  return client.request(query, variables);
+};
+
+export const StopPlacesQuery = (endpoint, query, variables) => {
+  const client = new GraphQLClient(endpoint, {
+    headers: { ...staticHeaders },
   });
   return client.request(query, variables);
 };

--- a/src/scenes/Lines/scenes/Editor/JourneyPatterns/Editor/StopPoints/Editor/searchForQuay.ts
+++ b/src/scenes/Lines/scenes/Editor/JourneyPatterns/Editor/StopPoints/Editor/searchForQuay.ts
@@ -1,4 +1,4 @@
-import { request } from 'graphql-request';
+import { StopPlacesQuery } from 'graphql';
 
 export type Quay = {
   id: string;
@@ -61,7 +61,7 @@ export default async function search(quayRef: string): Promise<QuaySearch> {
     quayRef,
   };
 
-  const data: null | SearchForQuayResponse = await request(
+  const data: null | SearchForQuayResponse = await StopPlacesQuery(
     endpoint,
     query,
     variables


### PR DESCRIPTION
We got rate limited on stop place queries, since we didn't include the proper client name header.