### PR TITLE
Passingtime input field fix

### DIFF
--- a/src/scenes/Lines/scenes/Editor/ServiceJourneys/Editor/PassingTimesEditor/index.tsx
+++ b/src/scenes/Lines/scenes/Editor/ServiceJourneys/Editor/PassingTimesEditor/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect, useSelector } from 'react-redux';
 import { Dropdown } from '@entur/dropdown';
 import { TimePicker } from '@entur/datepicker';
-import { InputGroup, TextField } from '@entur/form';
+import { InputGroup } from '@entur/form';
 import { ClockIcon } from '@entur/icons';
 import StopPoint from 'model/StopPoint';
 import PassingTime from 'model/PassingTime';

--- a/src/scenes/Lines/scenes/Editor/ServiceJourneys/Editor/PassingTimesEditor/index.tsx
+++ b/src/scenes/Lines/scenes/Editor/ServiceJourneys/Editor/PassingTimesEditor/index.tsx
@@ -17,6 +17,17 @@ import './styles.scss';
 import { getErrorFeedback } from 'helpers/errorHandling';
 import FlexibleAreasPassingTime from './FlexibleAreasPassingTime';
 
+const toDate = (date: string | undefined): Date | undefined => {
+  if (!date) return;
+  const [hours, minutes, seconds] = date.split(':');
+  const dateObj = new Date();
+  dateObj.setHours(parseInt(hours));
+  dateObj.setMinutes(parseInt(minutes));
+  dateObj.setSeconds(parseInt(seconds));
+
+  return dateObj;
+};
+
 type StateProps = {
   flexibleStopPlaces: FlexibleStopPlace[];
   intl: IntlState;
@@ -73,19 +84,11 @@ const PassingTimesEditor = (props: Props & StateProps) => {
     index: number,
     label: string
   ) => {
-    const departureTime = passingTime?.departureTime ?? '00:00:00';
-    const [hours, minutes, seconds] = departureTime.split(':');
-    const now = new Date();
-    now.setHours(parseInt(hours));
-    now.setMinutes(parseInt(minutes));
-    now.setSeconds(parseInt(seconds));
-
     return (
       <InputGroup label={label} className="timepicker">
         <TimePicker
           onChange={(e: Date | null) => {
-            if (!e) return;
-            const date = e.toTimeString().split(' ')[0];
+            const date = e?.toTimeString().split(' ')[0];
 
             onChange(
               changeElementAtIndex(
@@ -100,7 +103,7 @@ const PassingTimesEditor = (props: Props & StateProps) => {
             );
           }}
           prepend={<ClockIcon inline />}
-          selectedTime={now}
+          selectedTime={toDate(passingTime.departureTime)}
         />
       </InputGroup>
     );

--- a/src/scenes/Lines/scenes/Editor/ServiceJourneys/Editor/PassingTimesEditor/index.tsx
+++ b/src/scenes/Lines/scenes/Editor/ServiceJourneys/Editor/PassingTimesEditor/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect, useSelector } from 'react-redux';
 import { Dropdown } from '@entur/dropdown';
+import { TimePicker } from '@entur/datepicker';
 import { InputGroup, TextField } from '@entur/form';
 import { ClockIcon } from '@entur/icons';
 import StopPoint from 'model/StopPoint';
@@ -67,40 +68,39 @@ const PassingTimesEditor = (props: Props & StateProps) => {
     />
   );
 
-  const padTimePickerInput = (time: string): string | undefined => {
-    if (time.length === 0) return undefined;
-    return time + ':00';
-  };
-
   const getTimePicker = (
     passingTime: PassingTime,
     index: number,
     label: string
   ) => {
-    const shownValue = passingTime.departureTime
-      ?.split(':')
-      .slice(0, 2)
-      .join(':');
+    const departureTime = passingTime?.departureTime ?? '00:00:00';
+    const [hours, minutes, seconds] = departureTime.split(':');
+    const now = new Date();
+    now.setHours(parseInt(hours));
+    now.setMinutes(parseInt(minutes));
+    now.setSeconds(parseInt(seconds));
 
     return (
       <InputGroup label={label} className="timepicker">
-        <TextField
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+        <TimePicker
+          onChange={(e: Date | null) => {
+            if (!e) return;
+            const date = e.toTimeString().split(' ')[0];
+
             onChange(
               changeElementAtIndex(
                 passingTimes,
                 {
                   ...passingTimes[index],
-                  departureTime: padTimePickerInput(e.target.value),
-                  arrivalTime: padTimePickerInput(e.target.value),
+                  departureTime: date,
+                  arrivalTime: date,
                 },
                 index
               )
-            )
-          }
+            );
+          }}
           prepend={<ClockIcon inline />}
-          type="time"
-          defaultValue={shownValue}
+          selectedTime={now}
         />
       </InputGroup>
     );


### PR DESCRIPTION
The input field for passing times used input `type='time'` which is not supported by some browsers (e.g Safari). This led to some unintended behaviour. It is now fixed by using the TimePicker-component from EDS.