### PR TITLE
Redirect to lines overview only for fresh lines

### DIFF
--- a/src/scenes/Lines/scenes/Editor/index.tsx
+++ b/src/scenes/Lines/scenes/Editor/index.tsx
@@ -55,7 +55,7 @@ const FlexibleLineEditor = (props: Props) => {
     if (valid) {
       setSaving(true);
       dispatch(saveFlexibleLine(props.flexibleLine))
-        .then(() => goToLines())
+        .then(() => !props.isEdit && goToLines())
         .finally(() => setSaving(false));
       dispatch(setSavedChanges(true));
       setNextClicked(false);


### PR DESCRIPTION
The user should stay in edit-mode after save. For new lines, (s)he should be redirected to lines-overview