### PR TITLE
ROR-860 Fix for incorrect coordinate order

### DIFF
--- a/src/scenes/StopPlaces/scenes/Editor/index.tsx
+++ b/src/scenes/StopPlaces/scenes/Editor/index.tsx
@@ -45,15 +45,15 @@ import { getErrorFeedback } from 'helpers/errorHandling';
 import RequiredInputMarker from 'components/RequiredInputMarker';
 import { LeafletMouseEvent } from 'leaflet';
 
-// Show coordinates in GeoJson order [Long, Lat]
 const coordinatesToText = (polygonCoordinates: Coordinate[]): string =>
-  polygonCoordinates.length === 0
-    ? ''
-    : JSON.stringify(polygonCoordinates.map(([x, y]) => [y, x]));
+  JSON.stringify(polygonCoordinates);
 
-// Transform input coordinates from GeoJson order [Long, Lat] to [Lat, Long]
 const transformTextToCoordinates = (text: string): Coordinate[] =>
-  JSON.parse(text).map(([x, y]: Coordinate) => [y, x]);
+  JSON.parse(text);
+
+// Map expects coordinates in lat-lon order, whereas geojson has lon-lat
+const transformToMapCoordinates = (geojson: Coordinate[]): Coordinate[] =>
+  geojson.length === 0 ? geojson : geojson.map(([y, x]) => [x, y]);
 
 const FlexibleStopPlaceEditor = ({
   match,
@@ -140,10 +140,10 @@ const FlexibleStopPlaceEditor = ({
   }, [dispatch, history, flexibleStopPlace]);
 
   const handleMapOnClick = (e: LeafletMouseEvent) => {
-    const newCoordinates = addCoordinate(polygonCoordinates, [
-      e.latlng.lat,
-      e.latlng.lng,
-    ]);
+    // Convert coordinate from map to geojson long-lat order
+    const newCoordinate: Coordinate = [e.latlng.lng, e.latlng.lat];
+
+    const newCoordinates = addCoordinate(polygonCoordinates, newCoordinate);
     changePolygon({
       type: GEOMETRY_TYPE.POLYGON,
       coordinates: newCoordinates,
@@ -352,7 +352,7 @@ const FlexibleStopPlaceEditor = ({
                 )}
                 <PolygonMap
                   addCoordinate={handleMapOnClick}
-                  polygon={polygonCoordinates}
+                  polygon={transformToMapCoordinates(polygonCoordinates)}
                   undo={handleUndoClick}
                 />
               </div>


### PR DESCRIPTION
Fixes regression introduced by coordinate input text area. Map expects
coordinates to be in lat-lon order, whereas input area and uttu expects
geojson lon-lat order. The regression was that coordinates were sent to
uttu in lat-lon order.